### PR TITLE
docs(plugin): tighten manifest description + keywords for marketplace submission

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "aish",
       "source": ".",
-      "description": "TensorDock + Modal MCP servers, GPU detection skills, and ML workflow subagents.",
+      "description": "Provision GPU VMs (TensorDock) and run serverless GPU apps (Modal) from Claude Code.",
       "version": "0.1.1",
       "author": {
         "name": "Shubhankar (lonexreb)"
@@ -27,6 +27,10 @@
         "modal",
         "mcp",
         "ml",
+        "huggingface",
+        "cuda",
+        "nvidia",
+        "serverless",
         "infrastructure",
         "agents"
       ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "aish — agentic GPU cloud control plane for Claude Code.",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "plugins": [
     {
       "name": "aish",
       "source": ".",
       "description": "Provision GPU VMs (TensorDock) and run serverless GPU apps (Modal) from Claude Code.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "Shubhankar (lonexreb)"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aish",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Provision GPU VMs (TensorDock) and run serverless GPU apps (Modal) from Claude Code — bundled MCP servers, skills, and subagents.",
   "author": {
     "name": "Shubhankar (lonexreb)",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aish",
   "version": "0.1.1",
-  "description": "Agentic GPU cloud control plane for Claude Code: TensorDock + Modal MCP servers, GPU detection, and ML workflow subagents.",
+  "description": "Provision GPU VMs (TensorDock) and run serverless GPU apps (Modal) from Claude Code — bundled MCP servers, skills, and subagents.",
   "author": {
     "name": "Shubhankar (lonexreb)",
     "email": "reach2shubhankar@gmail.com",
@@ -11,14 +11,17 @@
   "repository": "https://github.com/lonexreb/aish",
   "license": "MIT",
   "keywords": [
-    "claude-code",
-    "claude-code-plugin",
     "mcp",
     "gpu",
     "tensordock",
     "modal",
     "ml",
+    "huggingface",
+    "cuda",
+    "nvidia",
+    "serverless",
     "infrastructure",
-    "cloud"
+    "cloud",
+    "agents"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] — 2026-04-30
+
+Patch release. Pre-submission polish on the plugin manifests so an Anthropic marketplace reviewer sees a clearer first impression. No code or behavior change — manifests only.
+
+### Changed
+
+- **`plugin.json` description** rewritten to lead with the verb (*Provision GPU VMs (TensorDock) and run serverless GPU apps (Modal) from Claude Code …*) instead of the buzzword "Agentic". Marketplace browsers truncate to the first ~80 chars, so those chars now describe what the plugin *does* rather than what it *is*.
+- **`plugin.json` keywords** dropped redundant `claude-code` / `claude-code-plugin` entries (every entry in the marketplace is a Claude Code plugin — wasted slots) and added `huggingface`, `cuda`, `nvidia`, `serverless`, `agents` so the searchable surface matches the actual user audience. 9 → 12 keywords.
+- **`marketplace.json`** plugin entry description and tag set updated to mirror `plugin.json` so a reviewer sees one consistent first impression in both manifests.
+
+### Internal
+
+- Version bumped in `plugin.json`, `marketplace.json` (top-level metadata + plugin entry), `pyproject.toml`, and `aish_mcp/__init__.py`.
+
 ## [0.1.1] — 2026-04-29
 
 Patch release. Closes 5 HIGH-severity bugs found by an extensive multi-reviewer audit (security, python-idiom, plan-conformance) that ran post-v0.1.0. **Recommended over v0.1.0 for any new install.**

--- a/aish_mcp/__init__.py
+++ b/aish_mcp/__init__.py
@@ -1,3 +1,3 @@
 """aish MCP servers — TensorDock REST and Modal CLI wrappers for Claude Code."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aish"
-version = "0.1.1"
+version = "0.1.2"
 description = "Claude Code plugin: GPU cloud MCP servers (TensorDock + Modal), GPU detection skills, and ML workflow subagents."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
## Summary

Pre-submission polish on the plugin manifests so an Anthropic marketplace reviewer sees a clearer first impression. No code or behavior change.

- **`plugin.json` description** now leads with the verb (*Provision GPU VMs … run serverless GPU apps …*) instead of buzzword-first. First ~80 chars are what marketplace browsers truncate to, so they should describe what the plugin does, not what it is.
- **`plugin.json` keywords** drop the redundant `claude-code` / `claude-code-plugin` entries (every entry in the marketplace is a Claude Code plugin — wasted slots) and add `huggingface`, `cuda`, `nvidia`, `serverless`, `agents` so the searchable surface matches the actual user audience. 9 → 12 keywords.
- **`marketplace.json`** mirrors the same wording + tag set so the plugin entry and the manifest agree.

Both manifests still parse as valid JSON; `.mcp.json` was already correct and is untouched. The `aish` name itself is preserved — renaming would invalidate v0.1.0 / v0.1.1 tags, the GitHub release, and the file:line citations in `docs/SUBMISSION.md` for marginal benefit.

## Test plan

- [x] `python3 -c "import json; json.load(open(p)) for p in [...]"` passes for all three manifests.
- [ ] CI: ruff + bandit + pytest + manifest validation should all stay green (no source files touched).
- [ ] Optional manual: `/plugin marketplace add ./` then re-discover to confirm new description renders as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin descriptions to highlight GPU virtual machine provisioning and serverless GPU application capabilities
  * Expanded plugin classification tags with GPU computing, AI framework, and serverless keywords for improved discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->